### PR TITLE
Fix build with clang12

### DIFF
--- a/libxlsxwriter-sys/build.rs
+++ b/libxlsxwriter-sys/build.rs
@@ -64,6 +64,8 @@ fn main() -> io::Result<()> {
     let mut build = cc::Build::new();
     build
         .include("third_party/libxlsxwriter/include")
+        .flag_if_supported("-Wno-implicit-function-declaration")
+        .flag_if_supported("-Wno-unused-parameter")
         .include("third_party/zlib");
     for path in &C_FILES[..] {
         assert_file_exists(path)?;


### PR DESCRIPTION
Add some new ignore warnings flags to the build to enable the libxlswriter-sys
subcrate to build properly.