### PR TITLE
fix compile error on target i686-pc-windows-msvc

### DIFF
--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -1069,7 +1069,7 @@ impl<'a> Worksheet<'a> {
                 row,
                 col,
                 buffer.as_ptr(),
-                buffer.len() as u64,
+                buffer.len() as libxlsxwriter_sys::size_t,
             );
             if result == libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {
                 Ok(())
@@ -1093,7 +1093,7 @@ impl<'a> Worksheet<'a> {
                 row,
                 col,
                 buffer.as_ptr(),
-                buffer.len() as u64,
+                buffer.len() as libxlsxwriter_sys::size_t,
                 &mut opt_struct,
             );
             if result == libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {


### PR DESCRIPTION
Use `libxlswriter_sys::size_t` instead of `u64`.