### PR TITLE
Allow newer versions of bindgen

### DIFF
--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["third_party/libxlsxwriter/docs", "third_party/libxlsxwriter/test", "
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.54"
+bindgen = "0.58"

--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["third_party/libxlsxwriter/docs", "third_party/libxlsxwriter/test", "
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.58"
+bindgen = "^0.54"


### PR DESCRIPTION
This PR loosens the version requirement of `bindgen` as `bindgen 0.54` depends on `clang-sys 0.29` while later versions depend on `clang-sys ^1`.
As many other libraries implement later versions of `bindgen` this might lead to conflicts during building. 