### PR TITLE
Allow newer versions of bindgen (fix of previous PR)

### DIFF
--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["third_party/libxlsxwriter/docs", "third_party/libxlsxwriter/test", "
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "^0.54"
+bindgen >= 0.54, <0.59

--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["third_party/libxlsxwriter/docs", "third_party/libxlsxwriter/test", "
 
 [build-dependencies]
 cc = "1.0"
-bindgen >= 0.54, <0.59
+bindgen >=0.54, <0.59

--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["third_party/libxlsxwriter/docs", "third_party/libxlsxwriter/test", "
 
 [build-dependencies]
 cc = "1.0"
-bindgen >=0.54, <0.59
+bindgen = ">= 0.54, < 0.59"


### PR DESCRIPTION
I just realized that the previous [PR](https://github.com/informationsea/xlsxwriter-rs/pull/15) does not loosen the bindgen version restriction as `bindgen = "^0.54"` it is equal to `>=0.54, <0.55`.
To allow the latest version of bindgen I now changed the requirement to  `>=0.54, <0.59` as this included the latest version.

Sorry for the confusion. ;)

It would be nice if you would also publish a new version of xslxwriter after merging. Thanks!