### PR TITLE
Add FFI for workbook_define_name

### DIFF
--- a/libxlsxwriter/src/workbook.rs
+++ b/libxlsxwriter/src/workbook.rs
@@ -122,6 +122,32 @@ impl Workbook {
         }
     }
 
+    pub fn define_name(
+        &self,
+        name: &str,
+        formula: &str,
+    ) -> Result<(), XlsxError> {
+        unsafe {
+            let result = libxlsxwriter_sys::workbook_define_name(
+                self.workbook,
+                CString::new(name)
+                .expect("Null Error")
+                .as_c_str()
+                .as_ptr(),
+                CString::new(formula)
+                .expect("Null Error")
+                .as_c_str()
+                .as_ptr()
+            );
+
+            if result == libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {
+                Ok(())
+            } else {
+                Err(XlsxError::new(result))
+            }
+        }
+    }
+
     pub fn close(mut self) -> Result<(), XlsxError> {
         unsafe {
             let result = libxlsxwriter_sys::workbook_close(self.workbook);


### PR DESCRIPTION
I needed to be able to use the `workbook_define_name` API so I added a function which wrapped that based on the [libxlsxwriter/defined_name.c](https://libxlsxwriter.github.io/defined_name_8c-example.html) docs.