### PR TITLE
Use std::os::raw::c_char instead of i8

### DIFF
--- a/libxlsxwriter/src/chart/mod.rs
+++ b/libxlsxwriter/src/chart/mod.rs
@@ -6,6 +6,7 @@ pub use self::constants::*;
 pub use self::series::*;
 pub use self::structs::*;
 use super::{convert_str, Workbook};
+use std::os::raw::c_char;
 
 /// The Chart object represents an Excel chart. It provides functions for adding data series to the chart and for configuring the chart.
 ///
@@ -177,11 +178,11 @@ impl<'a> Chart<'a> {
                 categories_vec
                     .as_ref()
                     .map(|x| x.as_ptr())
-                    .unwrap_or(std::ptr::null()) as *const i8,
+                    .unwrap_or(std::ptr::null()) as *const c_char,
                 values_vec
                     .as_ref()
                     .map(|x| x.as_ptr())
-                    .unwrap_or(std::ptr::null()) as *const i8,
+                    .unwrap_or(std::ptr::null()) as *const c_char,
             )
         };
         if let Some(x) = categories_vec {

--- a/libxlsxwriter/src/chart/series.rs
+++ b/libxlsxwriter/src/chart/series.rs
@@ -1,6 +1,7 @@
 use super::constants::*;
 use super::structs::*;
 use crate::{convert_bool, convert_str, Workbook, WorksheetCol, WorksheetRow};
+use std::os::raw::c_char;
 
 /// Struct to represent an Excel chart data series.
 /// This struct is created using the chart.add_series() function. It is used in functions that modify a chart series but the members of the struct aren't modified directly.
@@ -46,7 +47,7 @@ impl<'a> ChartSeries<'a> {
         unsafe {
             libxlsxwriter_sys::chart_series_set_categories(
                 self.chart_series,
-                sheet_name_vec.as_ptr() as *const i8,
+                sheet_name_vec.as_ptr() as *const c_char,
                 first_row,
                 first_column,
                 last_row,
@@ -71,7 +72,7 @@ impl<'a> ChartSeries<'a> {
         unsafe {
             libxlsxwriter_sys::chart_series_set_values(
                 self.chart_series,
-                sheet_name_vec.as_ptr() as *const i8,
+                sheet_name_vec.as_ptr() as *const c_char,
                 first_row,
                 first_column,
                 last_row,
@@ -138,7 +139,7 @@ impl<'a> ChartSeries<'a> {
         unsafe {
             libxlsxwriter_sys::chart_series_set_name(
                 self.chart_series,
-                name_vec.as_ptr() as *const i8,
+                name_vec.as_ptr() as *const c_char,
             );
         }
         self._workbook.const_str.borrow_mut().push(name_vec);
@@ -174,7 +175,7 @@ impl<'a> ChartSeries<'a> {
         unsafe {
             libxlsxwriter_sys::chart_series_set_name_range(
                 self.chart_series,
-                sheet_name_vec.as_ptr() as *const i8,
+                sheet_name_vec.as_ptr() as *const c_char,
                 row,
                 column,
             );

--- a/libxlsxwriter/src/validation.rs
+++ b/libxlsxwriter/src/validation.rs
@@ -1,5 +1,6 @@
 use super::{convert_bool, DateTime};
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub enum DataValidationType {
@@ -218,9 +219,11 @@ impl DataValidation {
                 })
                 .collect()
         });
-        let mut value_list_ptr: Option<Vec<*mut i8>> = value_list
-            .as_mut()
-            .map(|x| x.iter_mut().map(|y| y.as_mut_ptr() as *mut i8).collect());
+        let mut value_list_ptr: Option<Vec<*mut c_char>> = value_list.as_mut().map(|x| {
+            x.iter_mut()
+                .map(|y| y.as_mut_ptr() as *mut c_char)
+                .collect()
+        });
         if let Some(l) = value_list_ptr.as_mut() {
             l.push(std::ptr::null_mut());
         }
@@ -244,7 +247,7 @@ impl DataValidation {
                 value_formula: value_formula
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut()) as *mut c_char,
                 value_list: value_list_ptr
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
@@ -254,30 +257,32 @@ impl DataValidation {
                 minimum_formula: minimum_formula
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut())
+                    as *mut c_char,
                 minimum_datetime: (&self.minimum_datetime).into(),
                 maximum_number: self.maximum_number,
                 maximum_formula: maximum_formula
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut())
+                    as *mut c_char,
                 maximum_datetime: (&self.maximum_datetime).into(),
                 input_title: input_title
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut()) as *mut c_char,
                 input_message: input_message
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut()) as *mut c_char,
                 error_title: error_title
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut()) as *mut c_char,
                 error_message: error_message
                     .as_mut()
                     .map(|x| x.as_mut_ptr())
-                    .unwrap_or(std::ptr::null_mut()) as *mut i8,
+                    .unwrap_or(std::ptr::null_mut()) as *mut c_char,
             },
 
             value_formula,
@@ -297,7 +302,7 @@ impl DataValidation {
 pub(crate) struct CDataValidation {
     value_formula: Option<Vec<u8>>,
     value_list: Option<Vec<Vec<u8>>>,
-    value_list_ptr: Option<Vec<*mut i8>>,
+    value_list_ptr: Option<Vec<*mut c_char>>,
     minimum_formula: Option<Vec<u8>>,
     maximum_formula: Option<Vec<u8>>,
     input_title: Option<Vec<u8>>,

--- a/libxlsxwriter/src/workbook.rs
+++ b/libxlsxwriter/src/workbook.rs
@@ -1,6 +1,7 @@
 use super::{error, Chart, ChartType, Format, Worksheet, XlsxError};
 use std::cell::RefCell;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::rc::Rc;
 
 /// The Workbook is the main object exposed by the libxlsxwriter library. It represents the entire spreadsheet as you see it in Excel and internally it represents the Excel file as it is written on disk.
@@ -44,7 +45,7 @@ impl Workbook {
             if let Some(sheet_name) = name_vec.as_ref() {
                 let result = libxlsxwriter_sys::workbook_validate_sheet_name(
                     self.workbook,
-                    sheet_name.as_ptr() as *const i8,
+                    sheet_name.as_ptr() as *const c_char,
                 );
                 if result != libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {
                     return Err(XlsxError::new(result));
@@ -55,7 +56,7 @@ impl Workbook {
                 self.workbook,
                 name_vec
                     .as_ref()
-                    .map(|x| x.as_ptr() as *const i8)
+                    .map(|x| x.as_ptr() as *const c_char)
                     .unwrap_or(std::ptr::null()),
             );
 

--- a/libxlsxwriter/src/worksheet.rs
+++ b/libxlsxwriter/src/worksheet.rs
@@ -1,5 +1,6 @@
 use super::{convert_bool, Chart, DataValidation, Format, FormatColor, Workbook, XlsxError};
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct DateTime {
@@ -894,7 +895,7 @@ impl<'a> Worksheet<'a> {
             .zip(c_str.iter_mut())
             .map(|(x, y)| libxlsxwriter_sys::lxw_rich_string_tuple {
                 format: x.1.map(|z| z.format).unwrap_or(std::ptr::null_mut()),
-                string: y.as_mut_ptr() as *mut i8,
+                string: y.as_mut_ptr() as *mut c_char,
             })
             .collect();
         let mut rich_text_ptr: Vec<*mut libxlsxwriter_sys::lxw_rich_string_tuple> = rich_text


### PR DESCRIPTION
xlsxwriter miscompiles because of a type mismatch between `*(const|mut) (i8|u8)`. The actual type(-alias) is `c_char` is either `i8` or `u8`. This patch uses the type alias instead.