### PR TITLE
Fix locale-dependent number encodings

### DIFF
--- a/libxlsxwriter-sys/build.rs
+++ b/libxlsxwriter-sys/build.rs
@@ -5,10 +5,11 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-const C_FILES: [&str; 25] = [
+const C_FILES: [&str; 26] = [
     "third_party/libxlsxwriter/third_party/tmpfileplus/tmpfileplus.c",
     "third_party/libxlsxwriter/third_party/minizip/ioapi.c",
     "third_party/libxlsxwriter/third_party/minizip/zip.c",
+    "third_party/libxlsxwriter/third_party/dtoa/emyg_dtoa.c",
     "third_party/libxlsxwriter/src/app.c",
     "third_party/libxlsxwriter/src/chart.c",
     "third_party/libxlsxwriter/src/chartsheet.c",
@@ -100,6 +101,9 @@ fn main() -> io::Result<()> {
             .flag_if_supported("/utf-8")
             .include("include");
     }
+
+    // Make `libxlsxwriter` use DTOA for number formating to avoid locale-specific C functions.
+    build.define("USE_DTOA_LIBRARY", None);
 
     build.compile("libxlsxwriter.a");
 


### PR DESCRIPTION
This PR defines `USE_DTOA_LIBRARY` in order to fix #35. However it does not put this behind any feature flag and so will always compile `libxlsxwirter` with `USE_DTOA_LIBRARY`. If this is unwanted an alternative would be to have the same code, but put it behind a feature flag. In that case to should it probably be a negative feature flag as defining `USE_DTOA_LIBRARY` seems like the most sensible default option.