### PR TITLE
fix build error on macOS

### DIFF
--- a/libxlsxwriter/src/worksheet/filter.rs
+++ b/libxlsxwriter/src/worksheet/filter.rs
@@ -105,7 +105,7 @@ impl FilterRule {
     ) -> Result<libxlsxwriter_sys::lxw_filter_rule, XlsxError> {
         Ok(libxlsxwriter_sys::lxw_filter_rule {
             criteria: self.criteria.into_internal() as u8,
-            value_string: c_string_helper.add_opt(self.value.to_str())? as *mut std::ffi::c_char,
+            value_string: c_string_helper.add_opt(self.value.to_str())? as *mut std::os::raw::c_char,
             value: self.value.to_f64().unwrap_or_default(),
         })
     }
@@ -268,7 +268,7 @@ impl<'a> Worksheet<'a> {
         let mut cstring_helper = crate::CStringHelper::new();
         let mut cstr_list: Vec<_> = try_to_vec(
             list.iter()
-                .map(|x| Ok(cstring_helper.add(x)? as *mut std::ffi::c_char)),
+                .map(|x| Ok(cstring_helper.add(x)? as *mut std::os::raw::c_char)),
         )?;
         cstr_list.push(std::ptr::null_mut());
         unsafe {

--- a/libxlsxwriter/src/worksheet/mod.rs
+++ b/libxlsxwriter/src/worksheet/mod.rs
@@ -335,14 +335,14 @@ impl CommentOptions {
     ) -> Result<libxlsxwriter_sys::lxw_comment_options, XlsxError> {
         Ok(libxlsxwriter_sys::lxw_comment_options {
             visible: self.visible.into_internal() as u8,
-            author: workbook.register_option_str(self.author.as_deref())? as *mut std::ffi::c_char,
+            author: workbook.register_option_str(self.author.as_deref())? as *mut c_char,
             width: self.width.unwrap_or_default(),
             height: self.height.unwrap_or_default(),
             x_scale: self.x_scale.unwrap_or_default(),
             y_scale: self.y_scale.unwrap_or_default(),
             color: self.color.value(),
             font_name: workbook.register_option_str(self.font_name.as_deref())?
-                as *mut std::ffi::c_char,
+                as *mut c_char,
             font_size: self.font_size.unwrap_or_default(),
             font_family: self.font_family.unwrap_or_default(),
             start_row: self.start_row,


### PR DESCRIPTION
hello, it occurs a compile error when i was trying to use the crate in my project. here's the error message
```
error[E0412]: cannot find type `c_char` in module `std::ffi`
   --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/xlsxwriter-0.5.0/src/worksheet/filter.rs:108:91
    |
108 |             value_string: c_string_helper.add_opt(self.value.to_str())? as *mut std::ffi::c_char,
    |                                                                                           ^^^^^^ not found in `std::ffi`
    |
help: consider importing one of these items
    |
1   | use crate::c_char;
    |
1   | use std::os::raw::c_char;
    |

error[E0412]: cannot find type `c_char` in module `std::ffi`
   --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/xlsxwriter-0.5.0/src/worksheet/filter.rs:271:70
    |
271 |                 .map(|x| Ok(cstring_helper.add(x)? as *mut std::ffi::c_char)),
    |                                                                      ^^^^^^ not found in `std::ffi`
    |
help: consider importing one of these items
    |
1   | use crate::c_char;
    |
1   | use std::os::raw::c_char;
    |

error[E0412]: cannot find type `c_char` in module `std::ffi`
   --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/xlsxwriter-0.5.0/src/worksheet/mod.rs:338:93
    |
338 |             author: workbook.register_option_str(self.author.as_deref())? as *mut std::ffi::c_char,
    |                                                                                             ^^^^^^ not found in `std::ffi`
    |
help: consider importing one of these items
    |
5   | use crate::c_char;
    |
5   | use std::os::raw::c_char;
    |

error[E0412]: cannot find type `c_char` in module `std::ffi`
   --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/xlsxwriter-0.5.0/src/worksheet/mod.rs:345:35
    |
345 |                 as *mut std::ffi::c_char,
    |                                   ^^^^^^ not found in `std::ffi`
    |
help: consider importing one of these items
    |
5   | use crate::c_char;
    |
5   | use std::os::raw::c_char;
    |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `xlsxwriter` due to 4 previous errors
```