### PR TITLE
Update bindgen

### DIFF
--- a/libxlsxwriter-sys/Cargo.toml
+++ b/libxlsxwriter-sys/Cargo.toml
@@ -24,4 +24,4 @@ system-zlib = []
 
 [build-dependencies]
 cc = "1.0"
-bindgen = ">= 0.58, < 0.61"
+bindgen = ">= 0.63, < 0.64"

--- a/libxlsxwriter/src/worksheet/mod.rs
+++ b/libxlsxwriter/src/worksheet/mod.rs
@@ -1333,7 +1333,7 @@ impl<'a> Worksheet<'a> {
                 row,
                 col,
                 buffer.as_ptr(),
-                buffer.len() as libxlsxwriter_sys::size_t,
+                buffer.len(),
             );
             if result == libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {
                 Ok(())
@@ -1357,7 +1357,7 @@ impl<'a> Worksheet<'a> {
                 row,
                 col,
                 buffer.as_ptr(),
-                buffer.len() as libxlsxwriter_sys::size_t,
+                buffer.len(),
                 &mut opt_struct,
             );
             if result == libxlsxwriter_sys::lxw_error_LXW_NO_ERROR {


### PR DESCRIPTION
`size_t` has been aligned with `usize` [1], rendering the cast unnecessary.

[1] https://github.com/rust-lang/rust-bindgen/pull/2278

It would be great if you could also make a release of the `libxlsxwriter-sys` crate and reference it in the main crate, such that we can profit from the improvements in `libxlsxwriter-sys`.