### PR TITLE
Add AutoMinimum ConditionalFormatRuleType enum

### DIFF
--- a/libxlsxwriter/src/worksheet/conditional_format/mod.rs
+++ b/libxlsxwriter/src/worksheet/conditional_format/mod.rs
@@ -132,6 +132,8 @@ pub enum TopOrBottomCriteria {
 pub enum ConditionalFormatRuleTypes {
     /// Conditional format rule type: matches the minimum values in the range. Can only be applied to min_rule_type.
     Minimum,
+    /// Conditional format rule type: matches either 0 or the minimum value in the range, whichever is greater. Can only be applied to min_rule_type.
+    AutoMinimum,
     /// Conditional format rule type: use a number to set the bound.
     Number,
     /// Conditional format rule type: use a percentage to set the bound.
@@ -148,6 +150,7 @@ impl ConditionalFormatRuleTypes {
     pub(crate) fn into_internal_value(self) -> u8 {
         let val = match self {
             ConditionalFormatRuleTypes::Minimum => libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_MINIMUM,
+            ConditionalFormatRuleTypes::AutoMinimum => libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_AUTO_MIN,
             ConditionalFormatRuleTypes::Number => libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_NUMBER,
             ConditionalFormatRuleTypes::Percent => libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_PERCENT,
             ConditionalFormatRuleTypes::Percentile => libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_PERCENTILE,

--- a/libxlsxwriter/src/worksheet/conditional_format/mod.rs
+++ b/libxlsxwriter/src/worksheet/conditional_format/mod.rs
@@ -132,7 +132,7 @@ pub enum TopOrBottomCriteria {
 pub enum ConditionalFormatRuleTypes {
     /// Conditional format rule type: matches the minimum values in the range. Can only be applied to min_rule_type.
     Minimum,
-    /// Conditional format rule type: matches either 0 or the minimum value in the range, whichever is greater. Can only be applied to min_rule_type.
+    /// Conditional format rule type: matches either 0 or the minimum value in the range, whichever is least. Can only be applied to min_rule_type.
     AutoMinimum,
     /// Conditional format rule type: use a number to set the bound.
     Number,


### PR DESCRIPTION
`Automatic` is the default minimum type for data bars in Excel.  It differs from the `Minimum` by defaulting to `0` if no negative values are in the range.  The value will be used if there are negative values in the range.

The constant already exists at `libxlsxwriter_sys::lxw_conditional_format_rule_types_LXW_CONDITIONAL_RULE_TYPE_AUTO_MIN`, this PR adds it to the allowed enum of `ConditionalFormatRuleTypes`